### PR TITLE
better margin units

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -41,8 +41,13 @@ your `app.js` and your `bundler` should do the rest:
 ```jsx
 // app.js
 import { render } from 'preact'
-import { App } from './app'
 import '@peculiarjs/cssfull/lib/index.css'
+
+const App = () => (
+  <div className="m-40 debug">
+    The Spot!
+  </div>
+)
 
 render(<App />, document.getElementById('app'))
 ```
@@ -54,7 +59,7 @@ inject it as `stylesheet` directly into `html`:
 <html lang="en">
   <link rel="stylesheet" href="https://unpkg.com/@peculiarjs/cssfull@0.0.2/lib/border.css">
   <body>
-    <div class="border-debug">
+    <div class="border-debug pointer">
       Content 
     </div>
   </body>

--- a/readme.md
+++ b/readme.md
@@ -64,6 +64,17 @@ inject it as `stylesheet` directly into `html`:
 
 ## 3. <a name="naming"></a>Classes naming approach
 
+### Measurement units
+Majority of classes in this lib approach 2 main `measurement units`:
+* `%`
+* `px`
+
+For simplicity `%` is made the default and used everywhere except `margin`,
+so class `w-100` should be read like `width: 100%` and `top-50` like `top: 50%`.
+On the opposite, absolute values like `px` are used **only** for `margin`, so
+in that case `mr-20` means `margin-right: 20px` and `m-10` means `margin: 10px`.
+
+
 ### Shortenings
 
 It is **expected** that some utilities will be used **much more often**: `width`, `height`, `margins`
@@ -80,19 +91,10 @@ so for a better and easier readability in `HTML/JSX`, these utils names are shor
 }
 
 /* "mt" stands for margin-top */
-.mt-20px {
+.mt-20 {
   margin-top: 20px;
 }
 ```
-
-### Measurement units
-Majority of classes in this lib approach 2 main `measurement units`:
-* `%`
-* `px`
-
-For simplicity `%` is made the default, so class `w-100` should be read like `width: 100%`.
-On the opposite, absolute values like `px`, need additional `px` ending:
-`mr-20px` means `margin-right: 20px`.
 
 
 ## 4. <a name="overview"></a>Utils overview
@@ -158,6 +160,7 @@ Same but for **height**.
 
 Pretty Similiar approach to `width` and `height` classes is used for `margins`.
 There are mnemonic for every margin side:
+* `m` — `margin`
 * `mt` — `margin-top`
 * `mr` — `margin-right`
 * `mb` — `margin-bottom`
@@ -171,23 +174,23 @@ with a step of `5px` from `20px` to `50px`.
 .mt-0 {
   margin-top: 0;
 }
-.mt-1px {
+.mt-1 {
   margin-top: 1px;
 }
-.mt-2px {
+.mt-2 {
   margin-top: 2px;
 }
 ...
 
-.mt-20px {
+.mt-20 {
   margin-top: 20px;
 }
-.mt-25px {
+.mt-25 {
   margin-top: 25px;
 }
 ...
 
-.mt-50px {
+.mt-50 {
   margin-top: 50px;
 }
 ```

--- a/src/border.css
+++ b/src/border.css
@@ -1,6 +1,7 @@
 .border-none {
   border: none;
 }
+.debug,
 .border-debug {
-  border: 2px solid red;
+  border: 2px dashed red;
 }

--- a/src/cursor.css
+++ b/src/cursor.css
@@ -1,11 +1,9 @@
 .cursor-default {
   cursor: default;
 }
+.pointer,
 .cursor-pointer {
   cursor: pointer;
-}
-.cursor-auto {
-  cursor: auto;
 }
 .cursor-progress {
   cursor: progress;

--- a/src/margin.css
+++ b/src/margin.css
@@ -1,3 +1,86 @@
+/* common */
+.m-0 {
+  margin: 0;
+}
+.m-1 {
+  margin: 1px;
+}
+.m-2 {
+  margin: 2px;
+}
+.m-3 {
+  margin: 3px;
+}
+.m-4 {
+  margin: 4px;
+}
+.m-5 {
+  margin: 5px;
+}
+.m-6 {
+  margin: 6px;
+}
+.m-7 {
+  margin: 7px;
+}
+.m-8 {
+  margin: 8px;
+}
+.m-9 {
+  margin: 9px;
+}
+.m-10 {
+  margin: 10px;
+}
+.m-11 {
+  margin: 11px;
+}
+.m-12 {
+  margin: 12px;
+}
+.m-13 {
+  margin: 13px;
+}
+.m-14 {
+  margin: 14px;
+}
+.m-15 {
+  margin: 15px;
+}
+.m-16 {
+  margin: 16px;
+}
+.m-17 {
+  margin: 17px;
+}
+.m-18 {
+  margin: 18px;
+}
+.m-19 {
+  margin: 19px;
+}
+.m-20 {
+  margin: 20px;
+}
+.m-25 {
+  margin: 25px;
+}
+.m-30 {
+  margin: 30px;
+}
+.m-35 {
+  margin: 35px;
+}
+.m-40 {
+  margin: 40px;
+}
+.m-40 {
+  margin: 45px;
+}
+.m-50 {
+  margin: 50px;
+}
+
 /* top */ 
 .mt-0 {
   margin-top: 0;

--- a/src/margin.css
+++ b/src/margin.css
@@ -2,82 +2,82 @@
 .mt-0 {
   margin-top: 0;
 }
-.mt-1px {
+.mt-1 {
   margin-top: 1px;
 }
-.mt-2px {
+.mt-2 {
   margin-top: 2px;
 }
-.mt-3px {
+.mt-3 {
   margin-top: 3px;
 }
-.mt-4px {
+.mt-4 {
   margin-top: 4px;
 }
-.mt-5px {
+.mt-5 {
   margin-top: 5px;
 }
-.mt-6px {
+.mt-6 {
   margin-top: 6px;
 }
-.mt-7px {
+.mt-7 {
   margin-top: 7px;
 }
-.mt-8px {
+.mt-8 {
   margin-top: 8px;
 }
-.mt-9px {
+.mt-9 {
   margin-top: 9px;
 }
-.mt-10px {
+.mt-10 {
   margin-top: 10px;
 }
-.mt-11px {
+.mt-11 {
   margin-top: 11px;
 }
-.mt-12px {
+.mt-12 {
   margin-top: 12px;
 }
-.mt-13px {
+.mt-13 {
   margin-top: 13px;
 }
-.mt-14px {
+.mt-14 {
   margin-top: 14px;
 }
-.mt-15px {
+.mt-15 {
   margin-top: 15px;
 }
-.mt-16px {
+.mt-16 {
   margin-top: 16px;
 }
-.mt-17px {
+.mt-17 {
   margin-top: 17px;
 }
-.mt-18px {
+.mt-18 {
   margin-top: 18px;
 }
-.mt-19px {
+.mt-19 {
   margin-top: 19px;
 }
-.mt-20px {
+.mt-20 {
   margin-top: 20px;
 }
-.mt-25px {
+.mt-25 {
   margin-top: 25px;
 }
-.mt-30px {
+.mt-30 {
   margin-top: 30px;
 }
-.mt-35px {
+.mt-35 {
   margin-top: 35px;
 }
-.mt-40px {
+.mt-40 {
   margin-top: 40px;
 }
-.mt-45px {
+.mt-45 {
   margin-top: 45px;
 }
-.mt-50px {
+.mt-50 {
   margin-top: 50px;
 }
 
@@ -85,82 +85,82 @@
 .mr-0 {
   margin-right: 0;
 }
-.mr-1px {
+.mr-1 {
   margin-right: 1px;
 }
-.mr-2px {
+.mr-2 {
   margin-right: 2px;
 }
-.mr-3px {
+.mr-3 {
   margin-right: 3px;
 }
-.mr-4px {
+.mr-4 {
   margin-right: 4px;
 }
-.mr-5px {
+.mr-5 {
   margin-right: 5px;
 }
-.mr-6px {
+.mr-6 {
   margin-right: 6px;
 }
-.mr-7px {
+.mr-7 {
   margin-right: 7px;
 }
-.mr-8px {
+.mr-8 {
   margin-right: 8px;
 }
-.mr-9px {
+.mr-9 {
   margin-right: 9px;
 }
-.mr-10px {
+.mr-10 {
   margin-right: 10px;
 }
-.mr-11px {
+.mr-11 {
   margin-right: 11px;
 }
-.mr-12px {
+.mr-12 {
   margin-right: 12px;
 }
-.mr-13px {
+.mr-13 {
   margin-right: 13px;
 }
-.mr-14px {
+.mr-14 {
   margin-right: 14px;
 }
-.mr-15px {
+.mr-15 {
   margin-right: 15px;
 }
-.mr-16px {
+.mr-16 {
   margin-right: 16px;
 }
-.mr-17px {
+.mr-17 {
   margin-right: 17px;
 }
-.mr-18px {
+.mr-18 {
   margin-right: 18px;
 }
-.mr-19px {
+.mr-19 {
   margin-right: 19px;
 }
-.mr-20px {
+.mr-20 {
   margin-right: 20px;
 }
-.mr-25px {
+.mr-25 {
   margin-right: 25px;
 }
-.mr-30px {
+.mr-30 {
   margin-right: 30px;
 }
-.mr-35px {
+.mr-35 {
   margin-right: 35px;
 }
-.mr-40px {
+.mr-40 {
   margin-right: 40px;
 }
-.mr-45px {
+.mr-45 {
   margin-right: 45px;
 }
-.mr-50px {
+.mr-50 {
   margin-right: 50px;
 }
 
@@ -168,82 +168,82 @@
 .mb-0 {
   margin-bottom: 0;
 }
-.mb-1px {
+.mb-1 {
   margin-bottom: 1px;
 }
-.mb-2px {
+.mb-2 {
   margin-bottom: 2px;
 }
-.mb-3px {
+.mb-3 {
   margin-bottom: 3px;
 }
-.mb-4px {
+.mb-4 {
   margin-bottom: 4px;
 }
-.mb-5px {
+.mb-5 {
   margin-bottom: 5px;
 }
-.mb-6px {
+.mb-6 {
   margin-bottom: 6px;
 }
-.mb-7px {
+.mb-7 {
   margin-bottom: 7px;
 }
-.mb-8px {
+.mb-8 {
   margin-bottom: 8px;
 }
-.mb-9px {
+.mb-9 {
   margin-bottom: 9px;
 }
-.mb-10px {
+.mb-10 {
   margin-bottom: 10px;
 }
-.mb-11px {
+.mb-11 {
   margin-bottom: 11px;
 }
-.mb-12px {
+.mb-12 {
   margin-bottom: 12px;
 }
-.mb-13px {
+.mb-13 {
   margin-bottom: 13px;
 }
-.mb-14px {
+.mb-14 {
   margin-bottom: 14px;
 }
-.mb-15px {
+.mb-15 {
   margin-bottom: 15px;
 }
-.mb-16px {
+.mb-16 {
   margin-bottom: 16px;
 }
-.mb-17px {
+.mb-17 {
   margin-bottom: 17px;
 }
-.mb-18px {
+.mb-18 {
   margin-bottom: 18px;
 }
-.mb-19px {
+.mb-19 {
   margin-bottom: 19px;
 }
-.mb-20px {
+.mb-20 {
   margin-bottom: 20px;
 }
-.mb-25px {
+.mb-25 {
   margin-bottom: 25px;
 }
-.mb-30px {
+.mb-30 {
   margin-bottom: 30px;
 }
-.mb-35px {
+.mb-35 {
   margin-bottom: 35px;
 }
-.mb-40px {
+.mb-40 {
   margin-bottom: 40px;
 }
-.mb-45px {
+.mb-45 {
   margin-bottom: 45px;
 }
-.mb-50px {
+.mb-50 {
   margin-bottom: 50px;
 }
 
@@ -251,81 +251,81 @@
 .ml-0 {
   margin-left: 0;
 }
-.ml-1px {
+.ml-1 {
   margin-left: 1px;
 }
-.ml-2px {
+.ml-2 {
   margin-left: 2px;
 }
-.ml-3px {
+.ml-3 {
   margin-left: 3px;
 }
-.ml-4px {
+.ml-4 {
   margin-left: 4px;
 }
-.ml-5px {
+.ml-5 {
   margin-left: 5px;
 }
-.ml-6px {
+.ml-6 {
   margin-left: 6px;
 }
-.ml-7px {
+.ml-7 {
   margin-left: 7px;
 }
-.ml-8px {
+.ml-8 {
   margin-left: 8px;
 }
-.ml-9px {
+.ml-9 {
   margin-left: 9px;
 }
-.ml-10px {
+.ml-10 {
   margin-left: 10px;
 }
-.ml-11px {
+.ml-11 {
   margin-left: 11px;
 }
-.ml-12px {
+.ml-12 {
   margin-left: 12px;
 }
-.ml-13px {
+.ml-13 {
   margin-left: 13px;
 }
-.ml-14px {
+.ml-14 {
   margin-left: 14px;
 }
-.ml-15px {
+.ml-15 {
   margin-left: 15px;
 }
-.ml-16px {
+.ml-16 {
   margin-left: 16px;
 }
-.ml-17px {
+.ml-17 {
   margin-left: 17px;
 }
-.ml-18px {
+.ml-18 {
   margin-left: 18px;
 }
-.ml-19px {
+.ml-19 {
   margin-left: 19px;
 }
-.ml-20px {
+.ml-20 {
   margin-left: 20px;
 }
-.ml-25px {
+.ml-25 {
   margin-left: 25px;
 }
-.ml-30px {
+.ml-30 {
   margin-left: 30px;
 }
-.ml-35px {
+.ml-35 {
   margin-left: 35px;
 }
-.ml-40px {
+.ml-40 {
   margin-left: 40px;
 }
-.ml-45px {
+.ml-45 {
   margin-left: 45px;
 }
-.ml-50px {
+.ml-50 {
   margin-left: 50px;
 }


### PR DESCRIPTION
### Description
Migrate `margin` classes from `mt-20px` to just `mt-20` for easiness of use.

### What was done
- remove px part from margin classes
- add common margin classes for all sides
- update docs with recent margin units change
- add a few aliases for border & cursor classes
