### PR TITLE
add check_correctness method in build to prevent broken artifacts

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -81,10 +81,22 @@ prepare_modules() {
   done
 }
 
+check_correctness() {
+  for FILE in $OUTPUT/*; do
+    # checks if file is empty
+    if [[ $(wc -l < "${FILE}") -eq 0  ]]; then
+      echo "Build failed because ${FILE} output file is empty"
+      exit 1
+    fi
+  done
+
+}
+
 main() {
   recreate_output_dir
   prepare_modules 
   create_bundle
+  check_correctness
 }
 
 main


### PR DESCRIPTION
## Description
For some reason `build.sh` script doesn't work properly on CI and **randomly**
produces empty output files, so to prevent that `check_correctness` step is added